### PR TITLE
don't expect a namespace anymore

### DIFF
--- a/lib/mantle/message_bus.rb
+++ b/lib/mantle/message_bus.rb
@@ -26,7 +26,7 @@ module Mantle
 
       @redis.subscribe(@channels) do |on|
         on.message do |channel, message|
-          _, action, model = channel.split(":")
+          action, model = channel.split(":")
           MessageRouter.new("#{action}:#{model}", message).route!
         end
       end


### PR DESCRIPTION
Originally, I believe mantle was expecting a namespace to exist on the
messages it received. But now that we're not using namespaces (neither
static nor dynamic), I don't believe we want to account for it here
anymore.
