### PR TITLE
add optional whoami config and message_source if whoami is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.2.4
+-----------
+
+- Add `whoami` to mantle config so an app can tag published messages
+- Add `message_source` as a `__MANTLE__` payload so consumers can identify sender
+
 2.2.3
 -----------
 

--- a/lib/mantle/configuration.rb
+++ b/lib/mantle/configuration.rb
@@ -2,7 +2,8 @@ module Mantle
   class Configuration
     attr_accessor :message_bus_redis,
                   :logger,
-                  :redis_namespace
+                  :redis_namespace,
+                  :whoami
 
     attr_reader :message_handlers
 

--- a/lib/mantle/message.rb
+++ b/lib/mantle/message.rb
@@ -10,6 +10,7 @@ module Mantle
     end
 
     def publish(message)
+      message = message.merge(message_source: whoami) if whoami
       message_bus.publish(channel, message)
       catch_up.add_message(channel, message)
     end
@@ -17,5 +18,9 @@ module Mantle
     private
 
     attr_reader :message_bus, :catch_up
+
+    def whoami
+      Mantle.configuration.whoami
+    end
   end
 end

--- a/lib/mantle/message.rb
+++ b/lib/mantle/message.rb
@@ -10,7 +10,7 @@ module Mantle
     end
 
     def publish(message)
-      message = message.merge(message_source: whoami) if whoami
+      message = message.merge(__MANTLE__: { message_source: whoami }) if whoami
       message_bus.publish(channel, message)
       catch_up.add_message(channel, message)
     end

--- a/lib/mantle/version.rb
+++ b/lib/mantle/version.rb
@@ -1,3 +1,3 @@
 module Mantle
-  VERSION = '2.2.3'
+  VERSION = '2.2.4'
 end

--- a/spec/lib/mantle/configuration_spec.rb
+++ b/spec/lib/mantle/configuration_spec.rb
@@ -14,6 +14,12 @@ describe Mantle::Configuration do
     expect(config.message_handlers).to eq({'a_channel' => 'FakeHandler'})
   end
 
+  it 'can set/get whoami' do
+    config = Mantle::Configuration.new
+    config.whoami = 'SantaClaus'
+    expect(config.whoami).to eq('SantaClaus')
+  end
+
   it 'configures default message handler' do
     config = Mantle::Configuration.new
     expect(config.message_handlers).to be_instance_of(Mantle::MessageHandlers)

--- a/spec/lib/mantle/message_spec.rb
+++ b/spec/lib/mantle/message_spec.rb
@@ -12,10 +12,13 @@ describe Mantle::Message do
       mantle_message.message_bus = bus
       mantle_message.catch_up = catch_up
 
-      expect(bus).to receive(:publish).with(channel, message)
-      expect(catch_up).to receive(:add_message).with(channel, message)
+      allow(bus).to receive(:publish)
+      allow(catch_up).to receive(:add_message)
 
       mantle_message.publish(message)
+
+      expect(bus).to have_received(:publish).with(channel, message)
+      expect(catch_up).to have_received(:add_message).with(channel, message)
     end
 
     it "published message includes message_source" do
@@ -24,16 +27,19 @@ describe Mantle::Message do
       catch_up = double("catch up")
       channel = "create:person"
       message = { id: 1 }
-      actual_message = message.merge(message_source: 'SantaClaus')
+      actual_message = message.merge(__MANTLE__: { message_source: 'SantaClaus' })
 
       mantle_message = Mantle::Message.new(channel)
       mantle_message.message_bus = bus
       mantle_message.catch_up = catch_up
 
-      expect(bus).to receive(:publish).with(channel, actual_message)
-      expect(catch_up).to receive(:add_message).with(channel, actual_message)
+      allow(bus).to receive(:publish)
+      allow(catch_up).to receive(:add_message)
 
       mantle_message.publish(message)
+
+      expect(bus).to have_received(:publish).with(channel, actual_message)
+      expect(catch_up).to have_received(:add_message).with(channel, actual_message)
     end
   end
 end

--- a/spec/lib/mantle/message_spec.rb
+++ b/spec/lib/mantle/message_spec.rb
@@ -17,7 +17,23 @@ describe Mantle::Message do
 
       mantle_message.publish(message)
     end
+
+    it "published message includes message_source" do
+      Mantle.configure { |config| config.whoami = 'SantaClaus' }
+      bus = double("message bus")
+      catch_up = double("catch up")
+      channel = "create:person"
+      message = { id: 1 }
+      actual_message = message.merge(message_source: 'SantaClaus')
+
+      mantle_message = Mantle::Message.new(channel)
+      mantle_message.message_bus = bus
+      mantle_message.catch_up = catch_up
+
+      expect(bus).to receive(:publish).with(channel, actual_message)
+      expect(catch_up).to receive(:add_message).with(channel, actual_message)
+
+      mantle_message.publish(message)
+    end
   end
 end
-
-


### PR DESCRIPTION
Sometimes, it is necessary for an app to know where the message came from. This may violate  "message_bus" pattern, but at very least, it's nice to know if I sent the message I'm seeing :)