### PR TITLE
[LK-1047628642] Publish v2.3.0 requiring sidekiq 5.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+2.3.0
+-----------
+
+- Requires `sidekiq` versions `5.x` (previous releases required versions `4.x`)
+
 2.2.4
 -----------
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,25 @@
 PATH
   remote: .
   specs:
-    mantle (2.2.3)
+    mantle (2.3.0)
       redis
-      sidekiq (~> 4.0)
+      sidekiq (~> 5.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
     coderay (1.1.0)
-    concurrent-ruby (1.0.1)
-    connection_pool (2.2.0)
+    connection_pool (2.2.2)
     diff-lcs (1.2.5)
     method_source (0.8.2)
     pry (0.10.0)
       coderay (~> 1.1.0)
       method_source (~> 0.8.1)
       slop (~> 3.4)
-    redis (3.2.2)
+    rack (2.0.9)
+    rack-protection (2.0.8.1)
+      rack
+    redis (4.1.3)
     rspec (3.2.0)
       rspec-core (~> 3.2.0)
       rspec-expectations (~> 3.2.0)
@@ -31,10 +33,11 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
-    sidekiq (4.1.1)
-      concurrent-ruby (~> 1.0)
-      connection_pool (~> 2.2, >= 2.2.0)
-      redis (~> 3.2, >= 3.2.1)
+    sidekiq (5.2.8)
+      connection_pool (~> 2.2, >= 2.2.2)
+      rack (< 2.1.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.5, < 5)
     slop (3.5.0)
 
 PLATFORMS
@@ -46,4 +49,4 @@ DEPENDENCIES
   rspec
 
 BUNDLED WITH
-   1.11.2
+   2.1.4

--- a/lib/mantle/version.rb
+++ b/lib/mantle/version.rb
@@ -1,3 +1,3 @@
 module Mantle
-  VERSION = '2.2.4'
+  VERSION = '2.3.0'
 end

--- a/mantle.gemspec
+++ b/mantle.gemspec
@@ -6,8 +6,8 @@ require 'mantle/version'
 Gem::Specification.new do |gem|
   gem.name          = "mantle"
   gem.version       = Mantle::VERSION
-  gem.authors       = ["Scott Gibson", "Frank Hmeidan"]
-  gem.email         = ["sevgibson@gmail.com", "frank.hmeidan@gmail.com"]
+  gem.authors       = ["Grant Ammons", "Brandon Hilkert", "Scott Gibson", "Frank Hmeidan"]
+  gem.email         = ["gammons@gmail.com", "brandonhilkert@gmail.com", "sevgibson@gmail.com", "frank.hmeidan@gmail.com"]
   gem.description   = %q{Ruby application message bus subscriptions with Sidekiq and Redis Pubsub.}
   gem.summary       = %q{Ruby application message bus subscriptions with Sidekiq and Redis Pubsub.}
   gem.homepage      = "https://github.com/PipelineDeals/mantle"

--- a/mantle.gemspec
+++ b/mantle.gemspec
@@ -6,8 +6,8 @@ require 'mantle/version'
 Gem::Specification.new do |gem|
   gem.name          = "mantle"
   gem.version       = Mantle::VERSION
-  gem.authors       = ["Grant Ammons", "Brandon Hilkert", "Scott Gibson", "Frank Hmeidan"]
-  gem.email         = ["gammons@gmail.com", "brandonhilkert@gmail.com", "sevgibson@gmail.com", "frank.hmeidan@gmail.com"]
+  gem.authors       = ["Scott Gibson", "Frank Hmeidan"]
+  gem.email         = ["sevgibson@gmail.com", "frank.hmeidan@gmail.com"]
   gem.description   = %q{Ruby application message bus subscriptions with Sidekiq and Redis Pubsub.}
   gem.summary       = %q{Ruby application message bus subscriptions with Sidekiq and Redis Pubsub.}
   gem.homepage      = "https://github.com/PipelineDeals/mantle"
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_dependency('redis')
-  gem.add_dependency('sidekiq', '~> 4.0')
+  gem.add_dependency('sidekiq', '~> 5.0')
 
   gem.add_development_dependency('rspec')
   gem.add_development_dependency('pry')


### PR DESCRIPTION
https://pipelinedeals.leankit.com/card/1047628642

need to update `sidekiq-pro`, which requires updating `sidekiq` on which `mantle` also depends, hence we need to provide a version of the `mantle` gem that supports the `5.x` major versions of `sidekiq`.