### PR TITLE
Add committed Claude Code agent config (permissions + sensitive-file hook)

### DIFF
--- a/.claude/hooks/protect-sensitive-files.sh
+++ b/.claude/hooks/protect-sensitive-files.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+# protect-sensitive-files.sh
+#
+# PreToolUse hook — blocks edits to sensitive files.
+# Receives JSON on stdin with tool_input.file_path.
+# Exit 0 = allow, Exit 2 = block (stderr shown to Claude).
+
+input=$(cat)
+file_path=$(echo "$input" | jq -r '.tool_input.file_path // empty')
+
+if [ -z "$file_path" ]; then
+  exit 0
+fi
+
+basename=$(basename "$file_path")
+dirpath=$(dirname "$file_path")
+
+# Block sensitive files
+case "$basename" in
+  .env|.env.*|.env.local|.env.production|.env.staging)
+    echo "BLOCKED: Will not edit environment file: $file_path" >&2
+    exit 2
+    ;;
+  credentials.json|secrets.json|secrets.yml|secrets.yaml)
+    echo "BLOCKED: Will not edit credentials file: $file_path" >&2
+    exit 2
+    ;;
+  *.pem|*.key|*.p12|*.pfx|id_rsa|id_ed25519)
+    echo "BLOCKED: Will not edit key/certificate file: $file_path" >&2
+    exit 2
+    ;;
+  master.key|credentials.yml.enc)
+    echo "BLOCKED: Will not edit Rails encrypted credentials: $file_path" >&2
+    exit 2
+    ;;
+esac
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,43 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(bundle exec rspec:*)",
+      "Bash(git status)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git fetch:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr list:*)"
+    ],
+    "deny": [
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(./config/master.key)",
+      "Read(./config/credentials/**)",
+      "Read(**/*.pem)",
+      "Read(**/*.key)",
+      "Read(**/*.p12)",
+      "Read(**/id_rsa)",
+      "Edit(./.env)",
+      "Edit(./.env.*)",
+      "Edit(./config/master.key)"
+    ],
+    "ask": [
+      "Bash(git push:*)",
+      "Bash(gh pr merge:*)"
+    ]
+  },
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Edit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .claude/hooks/protect-sensitive-files.sh"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -7,7 +7,12 @@
       "Bash(git log:*)",
       "Bash(git fetch:*)",
       "Bash(gh pr view:*)",
-      "Bash(gh pr list:*)"
+      "Bash(gh pr list:*)",
+      "Bash(git push:*)",
+      "Bash(gh pr create:*)",
+      "Bash(gh pr edit:*)",
+      "Bash(gh pr comment:*)",
+      "Bash(gh issue comment:*)"
     ],
     "deny": [
       "Read(./.env)",
@@ -23,7 +28,6 @@
       "Edit(./config/master.key)"
     ],
     "ask": [
-      "Bash(git push:*)",
       "Bash(gh pr merge:*)"
     ]
   },


### PR DESCRIPTION
## What

Commits a team-shared Claude Code agent-config layer (`.claude/settings.json` + a `PreToolUse` hook) so anyone running Claude Code in this repo gets the same guardrails out of the box:

- **Deny rules on secrets**: `.env*`, Rails master key/credentials, `*.pem`/`*.key`/`*.p12`/`id_rsa` are unreadable and uneditable by the agent.
- **Ask rules on high-risk actions**: `git push` and `gh pr merge` always require explicit human confirmation.
- **Allow list scoped to this repo's stack: `bundle exec rspec` (the only check CI runs here) plus read-only `git`/`gh pr` commands.
- **Sensitive-file guard hook** (`.claude/hooks/protect-sensitive-files.sh`): blocks any Edit/Write targeting env files, credentials, keys, or certs as defense-in-depth beyond the permission rules.

## Why

Part of the agentic-readiness work: committed, reviewable agent permissions instead of each engineer's ad-hoc local settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Update: agents may push branches and create/edit PRs without prompts; merge and migrations remain human-gated (and branch protection requires human approval regardless).