### PR TITLE
Fleet v2: reusable review shim + config alignment

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -25,7 +25,21 @@
       "Read(**/id_rsa)",
       "Edit(./.env)",
       "Edit(./.env.*)",
-      "Edit(./config/master.key)"
+      "Edit(./config/master.key)",
+      "Read(**/id_ed25519)",
+      "Edit(**/id_ed25519)",
+      "Read(**/*.pfx)",
+      "Edit(**/*.pfx)",
+      "Read(**/credentials.json)",
+      "Edit(**/credentials.json)",
+      "Read(**/secrets.json)",
+      "Edit(**/secrets.json)",
+      "Read(**/secrets.yml)",
+      "Edit(**/secrets.yml)",
+      "Read(**/secrets.yaml)",
+      "Edit(**/secrets.yaml)",
+      "Read(**/credentials.yml.enc)",
+      "Edit(**/credentials.yml.enc)"
     ],
     "ask": [
       "Bash(gh pr merge:*)"

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,75 +1,49 @@
-# Claude auto-review: runs on every non-draft PR when opened or marked ready
-# for review; mention @claude in a PR comment to trigger a re-review.
-# Requires the org-level ANTHROPIC_API_KEY secret.
 name: Claude Code
+
+# Thin shim — review logic lives in the org-wide reusable workflow
+# (pipeline_deals/.github/workflows/claude-review-reusable.yml).
+# This file owns only: triggers, concurrency, and the repo-specific prompt.
 
 on:
   pull_request:
-    types: [opened, ready_for_review]
+    types: [opened, ready_for_review, synchronize]
   issue_comment:
     types: [created]
   pull_request_review_comment:
     types: [created]
 
+# One run at a time per PR (queued, never cancelled).
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  cancel-in-progress: false
+
 permissions:
   contents: read
   pull-requests: write
   issues: write
+  statuses: write
   actions: read
   id-token: write
 
 jobs:
   claude:
-    if: |
-      (github.event_name == 'pull_request' && github.event.pull_request.draft == false) ||
-      (github.event_name == 'issue_comment' && github.event.issue.pull_request && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
-    runs-on: ubuntu-latest
-    timeout-minutes: 15
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Acknowledge comment
-        # Only comment events carry github.event.comment; skip on pull_request
-        if: github.event_name != 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            if (context.eventName === 'pull_request_review_comment') {
-              await github.rest.reactions.createForPullRequestReviewComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                content: 'eyes'
-              });
-            } else {
-              await github.rest.reactions.createForIssueComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: context.payload.comment.id,
-                content: 'eyes'
-              });
-            }
-      - uses: anthropics/claude-code-action@v1
-        with:
-          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
-          prompt: |
-            Review this PR for a Pipeline CRM Ruby service. Focus on:
-            - Bugs or logic errors
-            - Account/tenant isolation — queries must scope by account_id;
-              flag unscoped find/where that could leak data across accounts
-            - Performance: N+1 queries, missing indexes, unbounded/unpaginated
-              queries, external calls (Redis, DB, HTTP) inside loops
-            - Sidekiq jobs: idempotent and safe to retry; pass record IDs, not
-              serialized objects
-            - Convention violations per this repo's CLAUDE.md, if present
+    uses: PipelineDeals/pipeline_deals/.github/workflows/claude-review-reusable.yml@master
+    secrets: inherit
+    # Caps inherit the reusable's defaults (30 turns / $1.50 / Sonnet).
+    with:
+      prompt: |
+        Review this PR for Mantle, Pipeline CRM's internal message bus gem
+        (published to rubygems.org as `mantle`). It is a packaged library with no
+        database — Rails apps use it to publish domain events over Redis pub/sub
+        and consume them via Sidekiq jobs. Focus on:
+        - Bugs or logic errors
+        - Public API compatibility — renamed methods, changed signatures, return
+          shapes, or configuration keys that would break existing gem consumers
+        - Thread safety — shared mutable state, lazily-initialized globals,
+          Redis connection reuse across threads
+        - Gemspec and dependency hygiene — version constraints (e.g. the
+          sidekiq < 7.0 pin), new runtime dependencies, supply chain risk
+        - Convention violations per this repo's AGENTS.md
 
-            You have full repo access. Read any files you need to verify your findings.
-            Only flag issues introduced by this PR, not pre-existing patterns.
-            Be concise. If the code is sound, say so in 2-3 sentences — do not
-            manufacture findings. Reserve detailed comments for real issues.
-          track_progress: true
-          include_fix_links: true
-          claude_args: "--model claude-sonnet-5 --max-turns 12 --max-budget-usd 0.75"
+        You have full repo access. Read any files you need to verify your findings.
+        Only flag issues introduced by this PR, not pre-existing patterns.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# CLAUDE.md — mantle
+# AGENTS.md — mantle
 
 Context file for AI agents and new developers. Verify against the code before
 relying on it; flag anything stale in a PR.


### PR DESCRIPTION
Converts this repo's Claude review workflow to a thin shim over the org-wide reusable workflow (`PipelineDeals/pipeline_deals/.github/workflows/claude-review-reusable.yml`).

- **Reusable review shim**: the shim owns only triggers, concurrency, and the repo-specific prompt. Review logic, caps, and generic guidance live in the reusable, so fleet-wide fixes become one PR to pipeline_deals while this repo keeps its own prompt.
- **Prompt rewritten for a library**: the old prompt reviewed a phantom Rails app (account_id scoping, N+1/index checks, Sidekiq job checklists, none of which apply to a DB-less packaged gem). The new prompt covers bugs, public-API compatibility for gem consumers, thread safety, gemspec/dependency hygiene, and conventions per AGENTS.md.
- **AGENTS.md header**: fixed the `# CLAUDE.md` heading left over from the rename.
- **Read-deny alignment**: extended `permissions.deny` in `.claude/settings.json` so Read is blocked for the same secret-file patterns the guard hook already Edit-blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
